### PR TITLE
FIX #5 -- Introduce new macro `XTEST_TESTING_DISABLED` to disable tests when building `xtest`'s tests together with the library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,15 @@ file(GLOB_RECURSE XTEST_SRC_FILES "xtest/*.cc")
 
 option(BUILD_TESTS "Builds the tests for library xtest itself." OFF)
 option(BUILD_SAMPLES "Builds the samples for library xtest." OFF)
+option(XTEST_TESTING_DISABLED "Disables building tests written for xtest." OFF)
 
 add_library(${PROJECT_NAME} SHARED ${XTEST_SRC_FILES})
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION} SOVERSION 1)
+
+if (XTEST_TESTING_DISABLED OR NOT BUILD_TESTS)
+	# Macro `XTEST_TESTING_DISABLED` is used to disable building tests for xtest.
+	add_compile_definitions(XTEST_TESTING_DISABLED)
+endif()
 
 install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_SOURCE_DIR}/build)
 

--- a/xtest/xtest-printers.cc
+++ b/xtest/xtest-printers.cc
@@ -156,14 +156,14 @@ void ColoredPrintf(const XTestColor& color, const char* fmt, ...) {
   va_list args;
   va_start(args, fmt);
 
-// The purpose why we use `XTEST_TESTING_ENABLED` macro to add the following
+// The purpose why we use `XTEST_TESTING_DISABLED` macro to add the following
 // code is because we need to test `ColoredPrintf()` function's output with
 // escape sequences and different console text attributes which is only possible
 // if we disable `ShouldUseColor()` function's result, because
 // `ShouldUseColor()` will always return `false` in testing because we
 // intentionally redirect `ColoredPrintf()` function's output to a context
 // buffer in order to check it.
-#if defined(XTEST_TESTING_ENABLED)
+#if defined(XTEST_TESTING_DISABLED)
   if (!ShouldUseColor(posix::IsAtty(posix::FileNo(stdout)) != 0)) {
     std::vprintf(fmt, args);
     va_end(args);


### PR DESCRIPTION
This macro is needed as out tests uses output redirection so to capture the output in a custom buffer to later check it with the expected output.  As we know `ColoredPrintf()` is the only gateway to our data to the console which internally uses function `ShouldUseColor()` that is bound to return `false` if any redirection happens.

This commit also fixes the problem with flag `--color` which was not working before because of the old macro `XTEST_TESTING_ENABLED` which we always forgot to define before building the library with samples.

There are two ways to define macro `XTEST_TESTING_DISABLED`:
  * Explicitly provide `XTEST_TESTING_DISABLED` option over the command line while
    building the library.
  * Removing `BUILD_TESTS` option from the command line while building the library.

Fixes #5 

Signed-off-by: Ayush Joshi <ayush854032@gmail.com>